### PR TITLE
Updated WordPress Importer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 *.sublime-*
 .DS_Store
 /.idea
+/wordpress-comments.xml

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -54,7 +54,7 @@ module.exports = {
        WHERE provider = ? AND provider_id = ?`,
 
   create_user:
-      `INSERT INTO user
+      `INSERT OR IGNORE INTO user
       (provider, provider_id, display_name, name, url,
        created_at, trusted, blocked)
       VALUES (?, ?, ?, ?, ?, datetime(), ?, 0)`,

--- a/src/importer.js
+++ b/src/importer.js
@@ -38,9 +38,15 @@ async function parse(file) {
 }
 
 function getWPAuthor(comment) {
+
+    let provider_id = comment['wp:comment_author'];
+    if (comment['wp:comment_user_id'].toString().length && !isNaN(comment['wp:comment_user_id'] * 1)) {
+        provider_id = comment['wp:comment_user_id']
+    }
+
     return [
         'wordpress',
-        comment['wp:comment_author'],
+        provider_id,
         comment['wp:comment_author'],
         comment['wp:comment_author'],
         0                   


### PR DESCRIPTION
* Added contributor's note for _Jerram Digital_
* Added real comments file to ignore list
* Prevent errors from being thrown, when an existing user is queried during import
* Corrected bug that prevented users from having more than one comment imported from WordPress
* Updated WP Importer to assign `user_id` to `source_id` field, instead of the author's _Display Name_